### PR TITLE
fix: fixed sor_ replacment

### DIFF
--- a/src/flachtex/rules/substitution_rules.py
+++ b/src/flachtex/rules/substitution_rules.py
@@ -70,8 +70,8 @@ def _sort_replacements(
     if len(replacements) <= 1:
         return replacements
     replacements_ = []
-    for i, e in enumerate(replacements[:-1]):
-        if e.intersects(replacements[i + 1]):
+    for i, e in enumerate(replacements):
+        if e.intersects(replacements[(i + 1) % len(replacements)]):
             continue
         else:
             replacements_ += [e]

--- a/src/flachtex/utils.py
+++ b/src/flachtex/utils.py
@@ -15,7 +15,7 @@ class Range:
         # one begin lies within the other
         if self.start <= other.start < self.end:
             return True
-        if other.start <= self.start < self.end:
+        if other.start <= self.start < self.end and not other.end <= self.start:
             return True
         return False
 


### PR DESCRIPTION
The last entry in the list replacements would have been ignored and was not being copied into replacements_. 

For this the for-loop was increased by form replacements[:-1] to replacements. 

To not trigger and index out of bounds error in the for-loop  we calculate i+1 modulo the length of the list to always stay inside the range.

For intersects to still work fine we had to modify the second if of intersect to check if the end of other was before self start. If this is true no intersection can occur. 
